### PR TITLE
feat : 베팅의 투두 삭제시 레디스에서 조회하도록 변경

### DIFF
--- a/src/main/java/site/doto/domain/betting/dto/BettingAddReq.java
+++ b/src/main/java/site/doto/domain/betting/dto/BettingAddReq.java
@@ -12,11 +12,11 @@ import javax.validation.constraints.NotNull;
 @Data
 public class BettingAddReq {
     @NotNull
-    Long todoId;
+    private Long todoId;
 
     @NotNull
     @Length(min = 2, max = 20)
-    String name;
+    private String name;
 
     public Betting toEntity(Member member, Todo todo) {
         ChatRoom chatRoom = new ChatRoom();

--- a/src/main/java/site/doto/domain/betting/dto/BettingDetailsRes.java
+++ b/src/main/java/site/doto/domain/betting/dto/BettingDetailsRes.java
@@ -4,7 +4,6 @@ import lombok.Data;
 import site.doto.domain.betting.entity.Betting;
 import site.doto.domain.member_betting.entity.MemberBetting;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Data
@@ -38,10 +37,8 @@ public class BettingDetailsRes {
         this.bettingName = betting.getName();
         this.memberId = betting.getMember().getId();
         this.memberNickname = betting.getMember().getNickname();
-        this.todoContents = betting.getTodo().getContents();
         this.chatRoomId = betting.getChatRoom().getId();
         this.isAchieved = betting.getIsAchieved();
-        this.isFinished = betting.getDate().isBefore(LocalDate.now());
         this.participantCount = memberBetting.size();
         this.successCoins = 0;
         this.failureCoins = 0;

--- a/src/main/java/site/doto/domain/betting/dto/BettingDetailsRes.java
+++ b/src/main/java/site/doto/domain/betting/dto/BettingDetailsRes.java
@@ -9,29 +9,29 @@ import java.util.List;
 
 @Data
 public class BettingDetailsRes {
-    Long bettingId;
+    private Long bettingId;
 
-    String bettingName;
+    private String bettingName;
 
-    Long chatRoomId;
+    private Long chatRoomId;
 
-    Long memberId;
+    private Long memberId;
 
-    String memberNickname;
+    private String memberNickname;
 
-    String todoContents;
+    private String todoContents;
 
-    Integer successCoins;
+    private Integer successCoins;
 
-    Integer failureCoins;
+    private Integer failureCoins;
 
-    Integer participantCount;
+    private Integer participantCount;
 
-    Boolean isParticipating;
+    private Boolean isParticipating;
 
-    Boolean isFinished;
+    private Boolean isFinished;
 
-    Boolean isAchieved;
+    private Boolean isAchieved;
 
     public BettingDetailsRes(Betting betting, List<MemberBetting> memberBetting, Long memberId) {
         this.bettingId = betting.getId();

--- a/src/main/java/site/doto/domain/betting/dto/BettingDto.java
+++ b/src/main/java/site/doto/domain/betting/dto/BettingDto.java
@@ -7,15 +7,15 @@ import site.doto.domain.betting.entity.Betting;
 @Data
 @Builder
 public class BettingDto {
-    Long bettingId;
+    private Long bettingId;
 
-    String bettingName;
+    private String bettingName;
 
-    Long memberId;
+    private Long memberId;
 
-    String memberNickname;
+    private String memberNickname;
 
-    String mainCharacterImg;
+    private String mainCharacterImg;
 
     static public BettingDto toDto(Betting betting) {
         return BettingDto.builder()

--- a/src/main/java/site/doto/domain/betting/dto/BettingJoinReq.java
+++ b/src/main/java/site/doto/domain/betting/dto/BettingJoinReq.java
@@ -11,10 +11,10 @@ import javax.validation.constraints.NotNull;
 @Data
 public class BettingJoinReq {
     @NotNull
-    Integer cost;
+    private Integer cost;
 
     @NotNull
-    Boolean prediction;
+    private Boolean prediction;
 
     public MemberBetting toEntity(Member member, Betting betting) {
         return MemberBetting.builder()

--- a/src/main/java/site/doto/domain/betting/dto/MyBettingListRes.java
+++ b/src/main/java/site/doto/domain/betting/dto/MyBettingListRes.java
@@ -3,29 +3,20 @@ package site.doto.domain.betting.dto;
 import lombok.Data;
 import site.doto.domain.betting.entity.Betting;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
 public class MyBettingListRes {
-
     private List<BettingDto> myBetting = new ArrayList<>();
 
     private List<BettingDto> joiningBetting = new ArrayList<>();
 
     private List<BettingDto> closedBetting = new ArrayList<>();
 
-    public MyBettingListRes(List<Betting> myBetting, List<Betting> bettingList) {
+    public MyBettingListRes(List<Betting> myBetting) {
         myBetting.stream()
                 .map(BettingDto::toDto)
                 .forEach(this.myBetting::add);
-
-        bettingList.stream()
-                .forEach(betting -> {
-                    List<BettingDto> list =
-                            betting.getDate().isBefore(LocalDate.now()) ? closedBetting : joiningBetting;
-                    list.add(BettingDto.toDto(betting));
-                });
     }
 }

--- a/src/main/java/site/doto/domain/betting/dto/MyBettingListRes.java
+++ b/src/main/java/site/doto/domain/betting/dto/MyBettingListRes.java
@@ -10,11 +10,11 @@ import java.util.List;
 @Data
 public class MyBettingListRes {
 
-    List<BettingDto> myBetting = new ArrayList<>();
+    private List<BettingDto> myBetting = new ArrayList<>();
 
-    List<BettingDto> joiningBetting = new ArrayList<>();
+    private List<BettingDto> joiningBetting = new ArrayList<>();
 
-    List<BettingDto> closedBetting = new ArrayList<>();
+    private List<BettingDto> closedBetting = new ArrayList<>();
 
     public MyBettingListRes(List<Betting> myBetting, List<Betting> bettingList) {
         myBetting.stream()

--- a/src/main/java/site/doto/domain/betting/dto/OpenBettingListRes.java
+++ b/src/main/java/site/doto/domain/betting/dto/OpenBettingListRes.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 
 @Data
 public class OpenBettingListRes {
-    List<BettingDto> openBetting;
+    private List<BettingDto> openBetting;
 
     public OpenBettingListRes(List<Betting> openBetting) {
         this.openBetting = openBetting.stream()

--- a/src/main/java/site/doto/domain/chat/dto/ChatAddReq.java
+++ b/src/main/java/site/doto/domain/chat/dto/ChatAddReq.java
@@ -7,5 +7,5 @@ import javax.validation.constraints.NotNull;
 @Data
 public class ChatAddReq {
     @NotNull
-    String contents;
+    private String contents;
 }

--- a/src/main/java/site/doto/domain/chat/dto/ChatDto.java
+++ b/src/main/java/site/doto/domain/chat/dto/ChatDto.java
@@ -8,16 +8,15 @@ import java.time.LocalDateTime;
 @Data
 @Builder
 public class ChatDto {
+    private Long chatId;
 
-    Long chatId;
+    private String contents;
 
-    String contents;
+    private LocalDateTime createdDate;
 
-    LocalDateTime createdDate;
+    private Long memberId;
 
-    Long memberId;
+    private String memberNickname;
 
-    String memberNickname;
-
-    String mainCharacterImg;
+    private String mainCharacterImg;
 }

--- a/src/main/java/site/doto/domain/chat/dto/ChatListReq.java
+++ b/src/main/java/site/doto/domain/chat/dto/ChatListReq.java
@@ -4,5 +4,5 @@ import lombok.Data;
 
 @Data
 public class ChatListReq {
-    Long lastChatId;
+    private Long lastChatId;
 }

--- a/src/main/java/site/doto/domain/chat/dto/ChatListRes.java
+++ b/src/main/java/site/doto/domain/chat/dto/ChatListRes.java
@@ -6,7 +6,7 @@ import site.doto.global.dto.SliceDto;
 
 @Data
 public class ChatListRes {
-    SliceDto<ChatDto> chats;
+    private SliceDto<ChatDto> chats;
 
     public ChatListRes(Slice<ChatDto> chats) {
         this.chats = new SliceDto<>(chats);

--- a/src/main/java/site/doto/domain/chatroom/dto/ChatRoomDto.java
+++ b/src/main/java/site/doto/domain/chatroom/dto/ChatRoomDto.java
@@ -6,16 +6,15 @@ import lombok.Data;
 @Data
 @Builder
 public class ChatRoomDto {
+    private Long chatRoomId;
 
-    Long chatRoomId;
+    private Long bettingId;
 
-    Long bettingId;
+    private String bettingName;
 
-    String bettingName;
+    private Long memberId;
 
-    Long memberId;
+    private String memberNickname;
 
-    String memberNickname;
-
-    String mainCharacterImg;
+    private String mainCharacterImg;
 }

--- a/src/main/java/site/doto/domain/chatroom/dto/ChatRoomListRes.java
+++ b/src/main/java/site/doto/domain/chatroom/dto/ChatRoomListRes.java
@@ -6,6 +6,5 @@ import java.util.List;
 
 @Data
 public class ChatRoomListRes {
-
-    List<ChatRoomDto> chatRooms;
+    private List<ChatRoomDto> chatRooms;
 }

--- a/src/main/java/site/doto/domain/todo/dto/TodoRedisDto.java
+++ b/src/main/java/site/doto/domain/todo/dto/TodoRedisDto.java
@@ -1,34 +1,31 @@
 package site.doto.domain.todo.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import site.doto.domain.todo.entity.Todo;
 
 import java.io.Serializable;
-
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TodoRedisDto implements Serializable {
-    private Long bettingId;
-
-    private Long todoId;
-
-    private Long memberId;
-
-    private Long categoryId;
-
-    private String categoryContents;
-
     private String contents;
 
-    public static TodoRedisDto toDto(Todo todo, Long id) {
+    private Integer year;
+
+    private Integer month;
+
+    private Integer date;
+
+    public static TodoRedisDto toDto(Todo todo) {
         return TodoRedisDto.builder()
-                .bettingId(id)
-                .todoId(todo.getId())
-                .memberId(todo.getMember().getId())
-                .categoryId(todo.getCategory().getId())
                 .contents(todo.getContents())
-                .categoryContents(todo.getCategory().getContents())
+                .year(todo.getDate().getYear())
+                .month(todo.getDate().getMonthValue())
+                .date(todo.getDate().getDayOfMonth())
                 .build();
     }
 }

--- a/src/main/java/site/doto/domain/todo/service/TodoService.java
+++ b/src/main/java/site/doto/domain/todo/service/TodoService.java
@@ -31,10 +31,16 @@ public class TodoService {
 
         Betting betting = bettingRepository.findBettingByTodo(todo);
 
-        TodoRedisDto todoRedisDto = TodoRedisDto.toDto(todo, betting.getId());
-        redisUtils.saveTodo(todoRedisDto);
+        TodoRedisDto todoRedisDto = TodoRedisDto.toDto(todo);
+        saveTodoToRedis(todoRedisDto, betting.getId());
 
         betting.todoDisconnected();
         bettingRepository.save(betting);
+    }
+
+    private void saveTodoToRedis(TodoRedisDto dto, Long bettingId) {
+        String key = "todo:" + bettingId;
+
+        redisUtils.setData(key, dto);
     }
 }

--- a/src/main/java/site/doto/global/redis/RedisEvent.java
+++ b/src/main/java/site/doto/global/redis/RedisEvent.java
@@ -17,7 +17,7 @@ public class RedisEvent {
         redisUtils.flushRedis();
     }
 
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     public void schedule() {
         redisUtils.updateRecordToDB();
         redisUtils.flushRedis();

--- a/src/main/java/site/doto/global/redis/RedisUtils.java
+++ b/src/main/java/site/doto/global/redis/RedisUtils.java
@@ -11,7 +11,6 @@ import site.doto.domain.record.dto.RecordUpdateDto;
 import site.doto.domain.record.entity.Record;
 import site.doto.domain.record.entity.RecordPK;
 import site.doto.domain.record.repository.RecordRepository;
-import site.doto.domain.todo.dto.TodoRedisDto;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -105,21 +104,5 @@ public class RedisUtils {
 
             recordRepository.updateRecord(update);
         }
-    }
-
-    public void saveTodo(TodoRedisDto todo) {
-        redisTemplate.opsForHash().put("todo:", longToString(todo.getBettingId()), todo);
-    }
-
-    public TodoRedisDto findTodo(Long id) {
-        return (TodoRedisDto) redisTemplate.opsForHash().get("todo:", longToString(id));
-    }
-
-    public void deleteTodo(Long id) {
-        redisTemplate.opsForHash().delete("todo:", longToString(id));
-    }
-
-    private String longToString(Long number) {
-        return String.valueOf(number);
     }
 }

--- a/src/test/java/site/doto/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/site/doto/domain/category/controller/CategoryControllerTest.java
@@ -20,6 +20,7 @@ import site.doto.domain.category.dto.CategoryModifyReq;
 import site.doto.domain.todo.dto.TodoRedisDto;
 import site.doto.global.redis.RedisUtils;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -673,6 +674,8 @@ class CategoryControllerTest {
         //given
         Long categoryId = 10002L;
 
+        System.out.println(LocalDate.now().toString());
+
         //when
         ResultActions actions = mockMvc.perform(
                 delete("/categories/{categoryId}", categoryId)
@@ -685,10 +688,11 @@ class CategoryControllerTest {
                 .andExpect(jsonPath("$.header.httpStatusCode").value(CATEGORY_DELETED.getHttpStatusCode()))
                 .andExpect(jsonPath("$.header.message").value(CATEGORY_DELETED.getMessage()));
 
-        TodoRedisDto savedTodo = redisUtils.findTodo(30005L);
+        TodoRedisDto savedTodo = (TodoRedisDto) redisUtils.getData("todo:" + 30005L);
         assertThat(savedTodo).isNotNull();
-        assertThat(savedTodo.getBettingId()).isEqualTo(30005L);
-        assertThat(savedTodo.getTodoId()).isEqualTo(20007L);
-        assertThat(savedTodo.getCategoryId()).isEqualTo(categoryId);
+        assertThat(savedTodo.getContents()).isEqualTo("투두7");
+        assertThat(savedTodo.getYear()).isEqualTo(LocalDate.now().minusDays(1).getYear());
+        assertThat(savedTodo.getMonth()).isEqualTo(LocalDate.now().minusDays(1).getMonthValue());
+        assertThat(savedTodo.getDate()).isEqualTo(LocalDate.now().minusDays(1).getDayOfMonth());
     }
 }


### PR DESCRIPTION
### PR Type
<!-- Please check the one that applies to this PR using "x".-->
- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약(Summary)
베팅의 투두 삭제시 레디스에서 조회하도록 변경

### 상세 내용(Describe your changes)
1. DTO에 누락된 접근 제한자를 추가
2. redis에 저장하는 투두의 데이터 변경
3. 종료된 베팅에 해당하는 투두가 DB에서 삭제되었을 경우 redis에서 데이터를 조회하도록 수정
4. redis를 flush하는 시각 변경

### Issue Number or Link
<!-- 
- Fixes: 이슈 수정중 (아직 해결되지 않은 경우)
- Resolves: 이슈를 해결했을 때 사용
- Ref: 참고할 이슈가 있을 때 사용
- Related to: 해당 커밋에 관련된 이슈번호 (아직 해결되지 않은 경우)
ex) Resolves: #4
-->Resolves: #120 
