### PR TITLE
fix : Record DB에 업데이트 시 redis flush 하지 않도록 변경

### DIFF
--- a/src/main/java/site/doto/domain/betting/service/BettingService.java
+++ b/src/main/java/site/doto/domain/betting/service/BettingService.java
@@ -264,6 +264,7 @@ public class BettingService {
         memberBettingRepository.deleteClosedMemberBetting();
         bettingRepository.deleteClosedBetting();
         chatRoomRepository.deleteOrphanChatRoom();
+        redisUtils.deleteTodoFromRedis();
     }
 
     public void closeBetting() {

--- a/src/main/java/site/doto/global/redis/RedisEvent.java
+++ b/src/main/java/site/doto/global/redis/RedisEvent.java
@@ -14,12 +14,10 @@ public class RedisEvent {
     @PostConstruct
     public void init() {
         redisUtils.updateRecordToDB();
-        redisUtils.flushRedis();
     }
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 3 * * *")
     public void schedule() {
         redisUtils.updateRecordToDB();
-        redisUtils.flushRedis();
     }
 }

--- a/src/main/java/site/doto/global/redis/RedisUtils.java
+++ b/src/main/java/site/doto/global/redis/RedisUtils.java
@@ -86,6 +86,7 @@ public class RedisUtils {
             String pk = split[0];
             String field = split[1];
             Integer variance = (Integer) getData(key);
+            deleteData(key);
 
             if (!map.containsKey(pk)) {
                 map.put(pk, new RecordUpdateDto(pk.split(":")));

--- a/src/main/java/site/doto/global/redis/RedisUtils.java
+++ b/src/main/java/site/doto/global/redis/RedisUtils.java
@@ -113,4 +113,12 @@ public class RedisUtils {
 
         setData(key, dto);
     }
+
+    public void deleteTodoFromRedis() {
+        Set<String> keys = findKeys("todo:*");
+
+        for (String key : keys) {
+            deleteData(key);
+        }
+    }
 }


### PR DESCRIPTION
### PR Type
<!-- Please check the one that applies to this PR using "x".-->
- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 상세 내용(Describe your changes)
 - redis에 저장되어있는 Record 기록을 DB에 업데이트 시 redis 전체를 flush하지 않고 해당 데이터만 삭제하도록 변경
 - 베팅 삭제 이후 redis에 저장되어 있는 투두 기록 삭제

### Issue Number or Link
<!-- 
- Fixes: 이슈 수정중 (아직 해결되지 않은 경우)
- Resolves: 이슈를 해결했을 때 사용
- Ref: 참고할 이슈가 있을 때 사용
- Related to: 해당 커밋에 관련된 이슈번호 (아직 해결되지 않은 경우)
ex) Resolves: #4
-->Resolves: #157 
